### PR TITLE
Fix typo in word "resources"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@
 		
 	- [UAV Trajectory Optimization for model completeness](#papers-uav-acquisition)
 
-- [OpenSource software ressources](#opensource)
+- [OpenSource software resources](#opensource)
 	- [SfM](#opensource-sfm)
 	- [Multiple View Geometry Library Solvers](#opensource-solvers)
 	- [MVS (Multiple View Stereovision)](#opensource-mvs)


### PR DESCRIPTION
OpenSource should also be "open source" or "open-source" with some choice of capitalization, but since "OpenSource" looked intentional, I left it alone.