### PR TITLE
Fix link to "... Refinement with Adaptive Resolution Control"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -262,7 +262,7 @@ R. Shah, A. Deshpande, P. J. Narayanan. 3DV 2014. -> [Multistage SFM: A Coarse-t
 
 [Global, Dense Multiscale Reconstruction for a Billion Points](https://lmb.informatik.uni-freiburg.de/people/ummenhof/multiscalefusion/). B. Ummenhofer, T. Brox. ICCV 2015.
 
-[Efficient Multi-view Surface Refinement with Adaptive Resolution Control](http://home.cse.ust.hk/~slibc/pdf/arc.pdf). S. Li, S. Yu Siu, T. Fang, L. Quan. ECCV 2016.
+[Efficient Multi-view Surface Refinement with Adaptive Resolution Control](http://slibc.student.ust.hk/pdf/arc.pdf). S. Li, S. Yu Siu, T. Fang, L. Quan. ECCV 2016.
 
 [Multi-View Inverse Rendering under Arbitrary Illumination and Albedo](http://www.ok.ctrl.titech.ac.jp/~torii/project/mvir/), K. Kim, A. Torii, M. Okutomi, ECCV2016.
 


### PR DESCRIPTION
[Old link](http://home.cse.ust.hk/~slibc/pdf/arc.pdf) returns 404.
Shiwei LI page (http://home.cse.ust.hk/~slibc) redirects here (http://slibc.student.ust.hk/).
So new paper url - http://slibc.student.ust.hk/pdf/arc.pdf.