### PR TITLE
Improve Kitware 2015 tutorial link(s)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,8 +76,6 @@
 [Large-scale, real-time visual-inertial localization revisited](https://storage.googleapis.com/pub-tools-public-publication-data/pdf/70c308dec1b9849921e969b1f36afd65c5884e29.pdf) S. Lynen, B. Zeisl, D. Aiger, M. Bosse, J. Hesch, M. Pollefeys, R. Siegwart and T. Sattler. Arxiv 2019.
 
 ## SfM tutorial
-[Open Source Structure-from-Motion](http://www.kitware.com/cvpr2015-tutorial.html). M. Leotta, S. Agarwal, F. Dellaert, P. Moulon, V. Rabaud. CVPR 2015 Tutorial.
-
 [Large-scale 3D Reconstruction from Images](https://home.cse.ust.hk/~tshenaa/sub/ACCV2016/ACCV_2016_Tutorial.html). T. Shen, J. Wang, T.Fang, L. Quan. ACCV 2016 Tutorial.
 
 ## MVS tutorial

--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@
 [Large-scale, real-time visual-inertial localization revisited](https://storage.googleapis.com/pub-tools-public-publication-data/pdf/70c308dec1b9849921e969b1f36afd65c5884e29.pdf) S. Lynen, B. Zeisl, D. Aiger, M. Bosse, J. Hesch, M. Pollefeys, R. Siegwart and T. Sattler. Arxiv 2019.
 
 ## SfM tutorial
-[Open Source Structure-from-Motion](http://www.kitware.com/cvpr2015-tutorial.html). M. Leotta, S. Agarwal, F. Dellaert, P. Moulon, V. Rabaud. CVPR 2015 Tutorial.
+[Open Source Structure-from-Motion](https://blog.kitware.com/open-source-structure-from-motion-at-cvpr-2015/). M. Leotta, S. Agarwal, F. Dellaert, P. Moulon, V. Rabaud. CVPR 2015 Tutorial [(material)](https://github.com/mleotta/cvpr2015-opensfm).
 
 [Large-scale 3D Reconstruction from Images](https://home.cse.ust.hk/~tshenaa/sub/ACCV2016/ACCV_2016_Tutorial.html). T. Shen, J. Wang, T.Fang, L. Quan. ACCV 2016 Tutorial.
 

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,8 @@
 [Large-scale, real-time visual-inertial localization revisited](https://storage.googleapis.com/pub-tools-public-publication-data/pdf/70c308dec1b9849921e969b1f36afd65c5884e29.pdf) S. Lynen, B. Zeisl, D. Aiger, M. Bosse, J. Hesch, M. Pollefeys, R. Siegwart and T. Sattler. Arxiv 2019.
 
 ## SfM tutorial
+[Open Source Structure-from-Motion](http://www.kitware.com/cvpr2015-tutorial.html). M. Leotta, S. Agarwal, F. Dellaert, P. Moulon, V. Rabaud. CVPR 2015 Tutorial.
+
 [Large-scale 3D Reconstruction from Images](https://home.cse.ust.hk/~tshenaa/sub/ACCV2016/ACCV_2016_Tutorial.html). T. Shen, J. Wang, T.Fang, L. Quan. ACCV 2016 Tutorial.
 
 ## MVS tutorial


### PR DESCRIPTION
Tutorial announcement with no learning materials.
It mentions "materials [...] available for download", but provides no
link.
It mentions "source code for the exercises on GitHub", but I could not
find any relevant repository.