### PR TITLE
Abandon "Map-Tk" in favor of "TeleSculptor"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -337,7 +337,7 @@ R. Shah, A. Deshpande, P. J. Narayanan. 3DV 2014. -> [Multistage SFM: A Coarse-t
 | ---  | --- | --- |
 |[Bundler](https://github.com/snavely/bundler_sfm) | C++ | GNU General Public License - contamination|
 |[Colmap](https://github.com/colmap/colmap) | C++ | BSD 3-clause license - Permissive |
-|[MAP-Tk](https://github.com/Kitware/maptk) | C++ | BSD 3-Clause license - Permissive |
+|[TeleSculptor](https://github.com/Kitware/TeleSculptor) | C++ | BSD 3-Clause license - Permissive |
 |[MicMac](https://github.com/micmacIGN) | C++ | CeCILL-B |
 |[MVE](https://github.com/simonfuhrmann/mve) | C++ | BSD 3-Clause license + parts under the GPL 3 license|
 |[OpenMVG](https://github.com/openMVG/openMVG) | C++ |  MPL2 - Permissive|


### PR DESCRIPTION
The project has been renamed, and the old repo URL redirects to the
current one.